### PR TITLE
feat(backend):Check quote expiry in outgoing payment worker (#3141)

### DIFF
--- a/packages/backend/src/open_payments/payment/outgoing/errors.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/errors.ts
@@ -110,5 +110,9 @@ export enum LifecycleError {
   MissingBalance = 'MissingBalance',
   MissingQuote = 'MissingQuote',
   MissingExpiration = 'MissingExpiration',
-  Unauthorized = 'Unauthorized'
+  Unauthorized = 'Unauthorized',
+
+  // To be thrown when a Quote has expired
+  QuoteExpired = 'QuoteExpired'
+
 }

--- a/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
+++ b/packages/backend/src/open_payments/payment/outgoing/lifecycle.ts
@@ -1,4 +1,4 @@
-import { LifecycleError } from './errors'
+import { LifecycleError, OutgoingPaymentError } from './errors'
 import {
   OutgoingPayment,
   OutgoingPaymentState,
@@ -16,6 +16,11 @@ export async function handleSending(
   payment: OutgoingPayment
 ): Promise<void> {
   if (!payment.quote) throw LifecycleError.MissingQuote
+
+  // Check if the current time is greater than or equal to when the Quote should be expiring
+  if (Date.now() >= payment.quote.expiresAt.getTime()) {
+    throw LifecycleError.QuoteExpired
+  } 
 
   const receiver = await deps.receiverService.get(payment.receiver)
 


### PR DESCRIPTION
 Check quote expiry in outgoing payment worker (#3141)



## Context
Currently, we check the expiresAt of the quote during outgoing payment creation. If it is valid, we create the outgoing payment, store it in the DB.

Once the payment is funded, the outgoing payments worker starts processing the payment, whether that is local or over ILP. If the payment fails, it will stay in the SENDING state and the worker will keep retrying it (up to some maximum number of times).

In the worker, however, we do not check the expiry of the quote. The quote could expire between the time when we created the payment, and when it is being processed (or retried) in the worker. We should prevent processing an outgoing payment for an expired quote. (good spot would be in lifecycle.ts > handleSending)

Also, so as to enable better error handling and debugging, we should add a new lifecycle error for showing quote has expired.

## Checklist

- [ ] Related tasks linked at `issue #3141`
- [ ] Add check if payment quote has expired under lifecycle.handleSending 
- [ ] Add QuoteExpired error under LifecycleError enum
